### PR TITLE
feat: exchange session id during initialization

### DIFF
--- a/schema/draft/schema.json
+++ b/schema/draft/schema.json
@@ -794,6 +794,9 @@
                         "protocolVersion": {
                             "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
                             "type": "string"
+                        },
+                        "sessionId": {
+                            "$ref": "#/definitions/SessionId"
                         }
                     },
                     "required": [
@@ -831,6 +834,9 @@
                 },
                 "serverInfo": {
                     "$ref": "#/definitions/Implementation"
+                },
+                "sessionId": {
+                    "$ref": "#/definitions/SessionId"
                 }
             },
             "required": [
@@ -2104,6 +2110,13 @@
                 {
                     "$ref": "#/definitions/CompleteResult"
                 }
+            ]
+        },
+        "SessionId": {
+            "description": "Globally unique and cryptographically secure session identifier.",
+            "type": [
+                "string",
+                "integer"
             ]
         },
         "SetLevelRequest": {

--- a/schema/draft/schema.ts
+++ b/schema/draft/schema.ts
@@ -60,6 +60,11 @@ export interface Result {
 export type RequestId = string | number;
 
 /**
+ * Globally unique and cryptographically secure session identifier.
+ */
+export type SessionId = string | number;
+
+/**
  * A request that expects a response.
  */
 export interface JSONRPCRequest extends Request {
@@ -158,6 +163,7 @@ export interface InitializeRequest extends Request {
     protocolVersion: string;
     capabilities: ClientCapabilities;
     clientInfo: Implementation;
+    sessionId?: SessionId;
   };
 }
 
@@ -178,6 +184,7 @@ export interface InitializeResult extends Result {
    * This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a "hint" to the model. For example, this information MAY be added to the system prompt.
    */
   instructions?: string;
+  sessionId?: SessionId;
 }
 
 /**


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Define Session ID on message layer and exchange it during initialization.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Currently, the Session ID concept exists only at the [StreamableHTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#session-management) layer. The ID is created by the server during initialization and exchanged via HTTP header.

The Session ID may be propagated into request context (currently done by the Python SDK), allowing implementations to leverage this information e.g. for session state. However, this only works with the aforementioned transport. Additionally, clients don't have the option to enter an existing session.

We propose to elevate the Session ID to the message layer, exchange it during initialization and allow clients to choose the session ID value.


## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

This PR aims to elevate the session concept introduced for [StreamableHTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports#session-management) to the protocol message level. This enables:
- Clients to join a session repeatedly or in parallel
- Support sessions over other transports

Keeping the copy of session id in HTTP header is useful for router/gateway MCP components.
